### PR TITLE
Fix: Bump package version

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,7 +12,7 @@ on:
       - "!**.md"
 env:
   PACKAGE_NAME: 'ghcr.io/archi-tektur/caddy-php'
-  PACKAGE_VERSION: '1.0.2'
+  PACKAGE_VERSION: '1.0.3'
 jobs:
   job0:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Git tags must be bumped each time, process will fail otherwise.